### PR TITLE
v1.1.21 - The "Hopefully Last Boar-O-Ween Prep #1" Update

### DIFF
--- a/example_config.json
+++ b/example_config.json
@@ -2606,6 +2606,13 @@
   },
   "itemConfigs": {
     "boars": {
+      "zombie": {
+        "name": "Zomboar",
+        "pluralName": "Zomboars",
+        "file": "ZombieBoar.png",
+        "description": "Zombification is impossible for boars, so this boar is actually just a cannibal in a costume. Still frightening either way.",
+        "isSB": false
+      },
       "normal": {
         "name": "Normal Boar",
         "pluralName": "Normal Boars",
@@ -2662,13 +2669,6 @@
         "pluralName": "Suboarnovas",
         "file": "Suboarnova.png",
         "description": "Some stars explode into this boar after they die out instead of a regular supernova. It's become a highly researched area of Boarstronomy.",
-        "isSB": false
-      },
-      "zombie": {
-        "name": "Zomboar",
-        "pluralName": "Zomboars",
-        "file": "ZombieBoar.png",
-        "description": "Zombification is impossible for boars, so this boar is actually just a cannibal in a costume. Still frightening either way.",
         "isSB": false
       },
       "bacteria": {
@@ -2787,6 +2787,18 @@
   },
   "rarityConfigs": [
     {
+      "name": "Wicked",
+      "pluralName": "Wickeds",
+      "weight": 826,
+      "baseScore": 20,
+      "fromDaily": false,
+      "enhancersNeeded": 0,
+      "avgClones": 100,
+      "boars": [
+        "zombie"
+      ]
+    },
+    {
       "name": "Common",
       "pluralName": "Commons",
       "weight": 825,
@@ -2883,18 +2895,6 @@
       ]
     },
     {
-      "name": "Spooky",
-      "pluralName": "Spookies",
-      "weight": 0.98,
-      "baseScore": 20,
-      "fromDaily": false,
-      "enhancersNeeded": 0,
-      "avgClones": 100,
-      "boars": [
-        "zombie"
-      ]
-    },
-    {
       "name": "Special",
       "weight": 0,
       "baseScore": 0,
@@ -2920,15 +2920,15 @@
     "green": "#55FF55",
     "maintenance": "#FFFF00",
     "error": "#FF5555",
-    "rarity1": "#FFFFFF",
-    "rarity2": "#00FF0F",
-    "rarity3": "#0064FF",
-    "rarity4": "#6400FF",
-    "rarity5": "#FFC500",
-    "rarity6": "#F300FF",
-    "rarity7": "#00FFFB",
-    "rarity8": "#ff6666,#ffb566,#fffa66,#74ff66,#666bff,#b966ff",
-    "rarity9": "#474747,#679311,#474747",
+    "rarity1": "#474747,#679311,#474747",
+    "rarity2": "#FFFFFF",
+    "rarity3": "#00FF0F",
+    "rarity4": "#0064FF",
+    "rarity5": "#6400FF",
+    "rarity6": "#FFC500",
+    "rarity7": "#F300FF",
+    "rarity8": "#00FFFB",
+    "rarity9": "#ff6666,#ffb566,#fffa66,#74ff66,#666bff,#b966ff",
     "rarity10": "#BC2326,#FF3136,#BC2326"
   }
 }

--- a/src/main/js/bot/BoarBot.ts
+++ b/src/main/js/bot/BoarBot.ts
@@ -26,7 +26,6 @@ import {BoarUtils} from '../util/boar/BoarUtils';
 import {ItemsData} from './data/global/ItemsData';
 import {GitHubData} from './data/global/GitHubData';
 import {GuildData} from './data/global/GuildData';
-import v8 from 'v8';
 
 /**
  * {@link BoarBot BoarBot.ts}
@@ -206,8 +205,6 @@ export class BoarBot implements Bot {
 	 */
 	private startNotificationCron(): void {
 		new CronJob('0 0 * * *', async () => {
-			v8.writeHeapSnapshot();
-
 			const userDataFolder = this.getConfig().pathConfig.databaseFolder +
 				this.getConfig().pathConfig.userDataFolder;
 
@@ -236,24 +233,36 @@ export class BoarBot implements Bot {
 						this.getConfig().pathConfig.guildDataFolder;
 
 					switch (randMsgIndex) {
-						case 5:
+						case 5: {
 							randMsgStr = randMsgStr.replace(
 								'%@', Object.keys(this.getConfig().itemConfigs.boars).length.toLocaleString()
 							);
 							break;
-						case 7:
+						}
+
+						case 7: {
 							randMsgStr = randMsgStr.replace(
 								'%@', fs.readdirSync(userDataFolder).length.toLocaleString()
 							);
 							break;
-						case 16:
+						}
+
+						case 16: {
 							randMsgStr = randMsgStr.replace(
 								'%@', fs.readdirSync(guildDataFolder).length.toLocaleString()
 							);
 							break;
-						case 17:
+						}
+
+						case 17: {
 							randMsgStr = randMsgStr.replace('%@', boarUser.stats.general.boarStreak.toLocaleString());
 							break;
+						}
+
+						case 20: {
+							randMsgStr = msgStrs[0];
+							break;
+						}
 					}
 
 					const curDate = new Date();

--- a/src/main/js/commands/boar/MarketSubcommand.ts
+++ b/src/main/js/commands/boar/MarketSubcommand.ts
@@ -729,7 +729,7 @@ export default class MarketSubcommand implements Subcommand {
         let hasEnoughRoom = true;
 
         const questData = DataHandlers.getGlobalData(DataHandlers.GlobalFile.Quest) as QuestData;
-        const isOwnOrder = this.firstInter.user.id !== orderInfo.data.userID;
+        const isOwnOrder = this.firstInter.user.id === orderInfo.data.userID;
 
         // This is meant to change whether items or bucks are returned
         // When cancelling, you get the opposite of what you wanted: your items back

--- a/src/main/js/util/boar/BoarUser.ts
+++ b/src/main/js/util/boar/BoarUser.ts
@@ -405,7 +405,7 @@ export class BoarUser {
                         itemsData.boars[boarID].lastBuys[1] = lastBuySell;
                         itemsData.boars[boarID].lastSells[1] = lastBuySell;
 
-                        if (rarityName !== 'Special' && rarityName !== 'Spooky') {
+                        if (rarityName !== 'Special' && rarityName !== 'Wicked') {
                             let specialEdition = 0;
                             if (!itemsData.boars['bacteria']) {
                                 itemsData.boars['bacteria'] = new ItemData();

--- a/src/main/js/util/boar/BoarUtils.ts
+++ b/src/main/js/util/boar/BoarUtils.ts
@@ -155,7 +155,7 @@ export class BoarUtils {
                 weight = 0;
             }
 
-            if (isHalloWeek && rarities[i].name === 'Spooky') {
+            if (isHalloWeek && rarities[i].name === 'Wicked') {
                 weight = rarities[0].weight;
             }
 


### PR DESCRIPTION
## Changes & Fixes
- Boar-o-ween notifications now ONLY send out the week leading up to Boar-o-ween
- Renamed "Spooky" rarity to "Wicked" to reduce confusion (spooky boar can easily get confused with the rarity)
- Wicked rarity now shows up last in inventories
- Fixed selling/buying from self on market counting toward quests (again)

## Dev changes
- Removed the creation of heap snapshots as the memory leak has been found and fixed
  - Logging of memory usage will persist so as to detect future leaks