### PR TITLE
v1.1.22 - The "Another Boar-O-Ween Prep Fixes" Update

### DIFF
--- a/example_config.json
+++ b/example_config.json
@@ -272,7 +272,7 @@
       "Did you know that a group of boar is called a sounder?",
       "Did you know that powerups spawn roughly every 2 hours? Use /boar help for more info!",
       "BoarBot exists in %@ different servers!",
-      "You have a boar streak of %@! The higher your boar streak, the more boar blessings you'll have'!",
+      "You have a boar streak of %@! The higher your boar streak, the more boar blessings you'll have!",
       "Want to suggest a new boar or feature? Join the server in my About Me!",
       "BoarBot has a lot more to it than just running /boar daily! To see everything BoarBot has to offer, use /boar help!",
       "Boar-o-ween happens every year on Halloween and consists of a series of intricate hunts and unique rewards. Interested in playing? Join the Discord server in my About Me!"
@@ -1033,7 +1033,7 @@
     "marketRange": 2,
     "orderExpire": 604800000,
     "notificationButtonDelay": 15000,
-    "questFullAmt": 2,
+    "questFullAmt": 3,
     "questImgSize": [
       1127,
       1500
@@ -2361,20 +2361,20 @@
       "valType": "rarity",
       "questVals": [
         [
-          1,
-          1
-        ],
-        [
           2,
           2
         ],
         [
           3,
-          1
+          3
         ],
         [
           4,
-          2
+          1
+        ],
+        [
+          5,
+          1
         ]
       ]
     },
@@ -2387,11 +2387,11 @@
       "questVals": [
         [
           10,
-          1
+          3
         ],
         [
           25,
-          2
+          5
         ],
         [
           50,
@@ -2399,7 +2399,7 @@
         ],
         [
           100,
-          2
+          1
         ]
       ]
     },
@@ -2412,11 +2412,11 @@
       "questVals": [
         [
           10,
-          1
+          3
         ],
         [
           25,
-          2
+          5
         ],
         [
           50,
@@ -2424,7 +2424,7 @@
         ],
         [
           100,
-          2
+          1
         ]
       ]
     },
@@ -2461,20 +2461,20 @@
       "valType": "rarity",
       "questVals": [
         [
-          1,
-          2
-        ],
-        [
           2,
-          4
+          3
         ],
         [
           3,
-          1
+          5
         ],
         [
           4,
-          2
+          1
+        ],
+        [
+          5,
+          1
         ]
       ]
     },
@@ -2499,7 +2499,7 @@
         ],
         [
           4,
-          2
+          1
         ]
       ]
     },
@@ -2512,11 +2512,11 @@
       "questVals": [
         [
           1,
-          1
+          3
         ],
         [
           2,
-          2
+          5
         ],
         [
           3,
@@ -2524,7 +2524,7 @@
         ],
         [
           4,
-          2
+          1
         ]
       ]
     },
@@ -2549,7 +2549,7 @@
         ],
         [
           16,
-          3
+          1
         ]
       ]
     },
@@ -2561,20 +2561,20 @@
       "valType": "time",
       "questVals": [
         [
-          5000,
+          6000,
           25
         ],
         [
-          3750,
+          4500,
           50
         ],
         [
-          2500,
+          3000,
           1
         ],
         [
-          1250,
-          3
+          1500,
+          1
         ]
       ]
     },
@@ -2587,11 +2587,11 @@
       "questVals": [
         [
           1,
-          1
+          2
         ],
         [
           2,
-          2
+          3
         ],
         [
           4,
@@ -2599,7 +2599,7 @@
         ],
         [
           6,
-          2
+          1
         ]
       ]
     }

--- a/src/main/js/bot/data/user/stats/GeneralStats.ts
+++ b/src/main/js/bot/data/user/stats/GeneralStats.ts
@@ -20,6 +20,10 @@ export class GeneralStats {
     public highestMulti = 0;
     public notificationsOn = false;
     public notificationChannel = '';
+    public spookEditions?: number[];
+    public spook3Stage?: number;
+    public spook5Stage?: number;
+    public truths?: boolean[];
     public unbanTime?: number; // No longer used, now stored globally
     public deletionTime?: number; // No longer used, now stored globally
 }

--- a/src/main/js/bot/handlers/ConfigHandler.ts
+++ b/src/main/js/bot/handlers/ConfigHandler.ts
@@ -67,10 +67,6 @@ export class ConfigHandler {
      * @private
      */
     private async validateConfig(parsedConfig: BotConfig): Promise<boolean> {
-        if (parsedConfig.maintenanceMode) {
-            return true;
-        }
-
         const rarities = parsedConfig.rarityConfigs;
         const boars = parsedConfig.itemConfigs.boars;
         const boarIDs = Object.keys(boars);
@@ -199,7 +195,7 @@ export class ConfigHandler {
             passed = false;
         }
 
-        return passed;
+        return passed || parsedConfig.maintenanceMode;
     }
 
     /**

--- a/src/main/js/commands/boar/CollectionSubcommand.ts
+++ b/src/main/js/commands/boar/CollectionSubcommand.ts
@@ -424,7 +424,7 @@ export default class CollectionSubcommand implements Subcommand {
         // The boar user will get if transmutation is successful
         const enhancedBoar = BoarUtils.findValid(this.allBoars[this.curPage].rarity[0], this.guildData, this.config);
 
-        if (enhancedBoar === '' || this.allBoars[this.curPage].rarity[0] >= 8) {
+        if (enhancedBoar === '' || this.allBoars[this.curPage].rarity[0] >= 9) {
             await LogDebug.handleError(this.config.stringConfig.dailyNoBoarFound, this.firstInter);
             return;
         }

--- a/src/main/js/commands/boar/MarketSubcommand.ts
+++ b/src/main/js/commands/boar/MarketSubcommand.ts
@@ -729,7 +729,6 @@ export default class MarketSubcommand implements Subcommand {
         let hasEnoughRoom = true;
 
         const questData = DataHandlers.getGlobalData(DataHandlers.GlobalFile.Quest) as QuestData;
-        const isOwnOrder = this.firstInter.user.id === orderInfo.data.userID;
 
         // This is meant to change whether items or bucks are returned
         // When cancelling, you get the opposite of what you wanted: your items back
@@ -746,7 +745,7 @@ export default class MarketSubcommand implements Subcommand {
         }
 
         // Counts progress toward spend bucks quest if claiming a buy order
-        if (!isSell && isClaim && !isOwnOrder) {
+        if (!isSell && isClaim) {
             const spendBucksIndex = questData.curQuestIDs.indexOf('spendBucks');
             this.boarUser.stats.quests.progress[spendBucksIndex] += numToReturn * orderInfo.data.price;
         }
@@ -784,7 +783,7 @@ export default class MarketSubcommand implements Subcommand {
             this.boarUser.stats.general.totalBoars += numToReturn;
             this.boarUser.itemCollection.boars[orderInfo.id].num += numToReturn;
 
-            const canCollectBoarQuest = collectBoarIndex >= 0 && isClaim && !isOwnOrder &&
+            const canCollectBoarQuest = collectBoarIndex >= 0 && isClaim &&
                 Math.floor(collectBoarIndex / 2) + 1 === BoarUtils.findRarity(orderInfo.id, this.config)[0];
 
             // Counts progress toward collecting boar rarity quest if claiming a boar buy order
@@ -811,10 +810,8 @@ export default class MarketSubcommand implements Subcommand {
             }
         } else if (isClaim) {
             // Counts collect bucks quest progress if claiming a sell order
-            if (!isOwnOrder) {
-                const collectBucksIndex = questData.curQuestIDs.indexOf('collectBucks');
-                this.boarUser.stats.quests.progress[collectBucksIndex] += numToReturn * orderInfo.data.price;
-            }
+            const collectBucksIndex = questData.curQuestIDs.indexOf('collectBucks');
+            this.boarUser.stats.quests.progress[collectBucksIndex] += numToReturn * orderInfo.data.price;
 
             this.boarUser.stats.general.boarScore += numToReturn * orderInfo.data.price;
         } else {

--- a/src/main/js/util/boar/BoarUtils.ts
+++ b/src/main/js/util/boar/BoarUtils.ts
@@ -151,7 +151,7 @@ export class BoarUtils {
             const curDate = new Date();
             const isHalloWeek = curDate.getMonth() === 9 && curDate.getDate() >= 24;
 
-            if (isHalloWeek && i === 0) {
+            if (isHalloWeek && rarities[i].name === 'Common') {
                 weight = 0;
             }
 

--- a/src/main/js/util/generators/CollectionImageGenerator.ts
+++ b/src/main/js/util/generators/CollectionImageGenerator.ts
@@ -580,7 +580,7 @@ export class CollectionImageGenerator {
 
         let cellImagePath = pathConfig.collAssets + pathConfig.cellNone;
         let chargeStr = 'No';
-        let chargeColor = colorConfig.rarity1;
+        let chargeColor = colorConfig.font;
 
         [...rarityConfigs].reverse().every((rarityConfig: RarityConfig, index: number) => {
             const notEnoughEnhancers = rarityConfig.enhancersNeeded === 0 ||
@@ -761,12 +761,12 @@ export class CollectionImageGenerator {
             if (i < 3) {
                 await CanvasUtils.drawText(
                     ctx, strConfig.collEnhancedLabel, nums.collEnhancedLabelPositions[i], mediumFont, 'center',
-                    colorConfig.font, undefined, false, [rarityConfig[i].pluralName], [colorConfig['rarity' + (i+1)]]
+                    colorConfig.font, undefined, false, [rarityConfig[i+1].pluralName], [colorConfig['rarity' + (i+2)]]
                 );
             } else {
                 await CanvasUtils.drawText(
                     ctx, rarityConfig[i].pluralName, nums.collEnhancedLabelPositions[i],
-                    mediumFont, 'center', colorConfig['rarity' + (i+1)]
+                    mediumFont, 'center', colorConfig['rarity' + (i+2)]
                 );
             }
 


### PR DESCRIPTION
## Changes
- Quest rewards balancing
  - Less transmutation charges from individual quests
  - More transmutation charges from full completion
  - More powerup rewards overall

## Fixes
- Wicked Boars now replace Common Boars in daily loot pool like they should
- Fixed Wicked Rarity being present where it shouldn't
- Fixed Divines being impossible to transmute
- Orders now count toward quest progress like they should

## Backend changes
- Bot now says when things are wrong on start like it should
- Added tracking of user's spooky stats
