### PR TITLE
v1.1.23 - The "Making a New Rarity Was a Mistake" Update

### DIFF
--- a/src/main/js/bot/BoarBot.ts
+++ b/src/main/js/bot/BoarBot.ts
@@ -267,7 +267,7 @@ export class BoarBot implements Bot {
 
 					const curDate = new Date();
 					if (curDate.getMonth() === 9 && curDate.getDate() >= 24) {
-						randMsgStr = msgStrs[20];
+						randMsgStr = '## ' + msgStrs[20] + '\n';
 					}
 
 					const notificationChannelID = boarUser.stats.general.notificationChannel

--- a/src/main/js/commands/boar/CollectionSubcommand.ts
+++ b/src/main/js/commands/boar/CollectionSubcommand.ts
@@ -461,7 +461,7 @@ export default class CollectionSubcommand implements Subcommand {
                 this.boarUser.stats.general.totalBoars--;
                 this.boarUser.itemCollection.powerups.enhancer.numTotal = 0;
                 (this.boarUser.itemCollection.powerups.enhancer.raritiesUsed as number[])[
-                    this.allBoars[this.curPage].rarity[0]-1
+                    this.allBoars[this.curPage].rarity[0]-2
                 ]++;
                 this.boarUser.stats.quests.progress[spendBucksIndex] += enhancersNeeded * 5;
 

--- a/src/main/js/util/boar/BoarUser.ts
+++ b/src/main/js/util/boar/BoarUser.ts
@@ -115,8 +115,8 @@ export class BoarUser {
 
         const cloneRaritiesNew = userData.itemCollection.powerups.clone.raritiesUsed as number[];
         const cloneRarities = this.itemCollection.powerups.clone.raritiesUsed as number[];
-        this.stats.quests.progress[cloneRarityIndex] += cloneRarities[Math.floor(cloneRarityIndex / 2)] -
-            cloneRaritiesNew[Math.floor(cloneRarityIndex / 2)];
+        this.stats.quests.progress[cloneRarityIndex] += cloneRarities[Math.floor(cloneRarityIndex / 2) + 1] -
+            cloneRaritiesNew[Math.floor(cloneRarityIndex / 2) + 1];
 
         this.stats.quests.progress[sendGiftsIndex] += this.itemCollection.powerups.gift.numUsed -
             userData.itemCollection.powerups.gift.numUsed;
@@ -253,7 +253,12 @@ export class BoarUser {
         if (!this.itemCollection.powerups.clone) {
             this.itemCollection.powerups.clone = new CollectedPowerup();
             this.itemCollection.powerups.clone.numSuccess = 0;
-            this.itemCollection.powerups.clone.raritiesUsed = [0,0,0,0,0,0,0];
+            this.itemCollection.powerups.clone.raritiesUsed = [0,0,0,0,0,0,0,0,0];
+        }
+
+        if ((this.itemCollection.powerups.clone.raritiesUsed as number[]).length === 7) {
+            (this.itemCollection.powerups.clone.raritiesUsed as number[]).push(0);
+            (this.itemCollection.powerups.clone.raritiesUsed as number[]).unshift(0);
         }
 
         this.itemCollection.powerups.miracle.numTotal = Math.max(

--- a/src/main/js/util/generators/CollectionImageGenerator.ts
+++ b/src/main/js/util/generators/CollectionImageGenerator.ts
@@ -765,7 +765,7 @@ export class CollectionImageGenerator {
                 );
             } else {
                 await CanvasUtils.drawText(
-                    ctx, rarityConfig[i].pluralName, nums.collEnhancedLabelPositions[i],
+                    ctx, rarityConfig[i+1].pluralName, nums.collEnhancedLabelPositions[i],
                     mediumFont, 'center', colorConfig['rarity' + (i+2)]
                 );
             }


### PR DESCRIPTION
## Fixes
- DM for boar-o-ween is now formatted properly
  - Although not in the files, the legacy server message now tells users about boar-o-ween
- Fixed clone rarity quests not registering properly
- Fixed divine and immaculate clones not being tracked
- Fixed rarity names being wrong in transmutation part of collection
- Fixed divine transmutation stats not tracking