### PR TITLE
fix council rarity chance

### DIFF
--- a/src/main/js/commands/boar/DailySubcommand.ts
+++ b/src/main/js/commands/boar/DailySubcommand.ts
@@ -111,7 +111,10 @@ export default class DailySubcommand implements Subcommand {
 
                     // Increases chance of truth boars until it's guaranteed at 10m blessings
                     // .01% at 1k | .1% at 10k | 1% at 100k | 10% at 1m | 100% at 10m
-                    rarityWeights.set(9, totalWeight / (10000000 / userMultiplier));
+                    rarityWeights.set(9, totalWeight * (userMultiplier / 10000000));
+                    for (let i = 1; i < 8; i++){
+                        rarityWeights.set(i, rarityWeights.get(i)! * userMultiplier / 10000000)
+                    }
                 }
 
                 // Probability of rolling extra boars


### PR DESCRIPTION
The council rarity did not adjust the weights to the correct amounts, making the actual chance of getting a council boar much lower than it should have been.

This sets the weight of truth boars to a percentage multiplied by the total weight of all boars, then lowers the other rarities weights by that same percentage.
For example, if there were 4 rarities, with weights of 1, 10, 50, and 100, and there was a truth chance of 50%, it would do the following:
The total weight is 161. 161 * 50% = 80.5
80.5 is the truth boar weight.
1 * 50% = 0.5, 10 * 50% = 5, 50 * 50% = 25, 100 * 50% = 50.
80.5 is the weight of all rarities besides council, giving council boars a 50% chance while keeping the chances of all other boar rarities proportional to what they were before.

Here is a list of the rarities at ~5m blessings. 1 is common, 7 is divine, 9 is council.
![weights](https://github.com/BoarBotDevs/BoarBot/assets/151677194/6edcd62b-7d4f-4685-845c-e29f57c981a8)

Above 10m blessings, weights will be negative. This does not seem to affect the results.
On my testing bot, this gave special boars from daily. I assume this is because council rarity doesn't exist on the public github and rarity 9 is special.