### PR TITLE
Rickroll images being spammed

### DIFF
--- a/src/main/js/util/generators/ItemImageGenerator.ts
+++ b/src/main/js/util/generators/ItemImageGenerator.ts
@@ -142,7 +142,6 @@ export class ItemImageGenerator {
         fs.writeFileSync(tempAnimBasePath, this.buffer);
 
         const scriptOptions = {
-            pythonPath: 'py',
             args: [
                 JSON.stringify(this.config.pathConfig),
                 JSON.stringify(this.config.numberConfig),
@@ -231,7 +230,6 @@ export class ItemImageGenerator {
         const script = this.config.pathConfig.userOverlayScript;
 
         const scriptOptions = {
-            pythonPath: 'py',
             args: [
                 JSON.stringify(this.config.pathConfig),
                 JSON.stringify(this.config.colorConfig),


### PR DESCRIPTION
Getting a Rickroll boar in any way on my test bot caused the image to be spammed endlessly with these 2 lines of code in the program. The same did not happen with Sphere.
The following image was in response to one /boar-dev give command. The same also happens when getting it from daily or transmuting.

![image](https://github.com/BoarBotDevs/BoarBot/assets/151677194/c30d5fdf-691f-46e8-bb87-ce7475fccf4c)
