### PR TITLE
v1.1.30 - The "Boarmas" Update

### DIFF
--- a/example_config.json
+++ b/example_config.json
@@ -190,8 +190,8 @@
     "eventsDisabled": "This server is missing out on powerups! To allow them to spawn, make sure BoarBot has the permissions it requests when you click \"Add To Server\" under its profile!",
     "powRightFull": "%@ It took you %@ to guess correctly! You'll receive %@ once the powerup event ends!",
     "powRight": "Correct!",
-    "powWrongFirst": "%@ You have one more guess!",
-    "powWrongSecond": "%@ You have no more guesses!",
+    "powWrongFirst": "%@ Try again!",
+    "powWrongSecond": "%@ You guessed incorrectly twice! Event Failed!",
     "powWrong": "Incorrect!",
     "powNoMore": "You've guessed incorrectly too many times! Better luck next time!",
     "powTop": "Perfect Powerup! - #1 Claimer",
@@ -277,7 +277,8 @@
       "You have a boar streak of %@! The higher your boar streak, the more boar blessings you'll have!",
       "Want to suggest a new boar or feature? Join the server in my About Me!",
       "BoarBot has a lot more to it than just running /boar daily! To see everything BoarBot has to offer, use /boar help!",
-      "Boar-o-ween happens every year on Halloween and consists of a series of intricate hunts and unique rewards. Interested in playing? Join our Discord server: https://discord.gg/DXSwKHYrCa"
+      "Boar-o-ween happens every year on Halloween and consists of a series of intricate hunts and unique rewards. Interested in playing? Join our Discord server: https://discord.gg/DXSwKHYrCa",
+      "Boarmas is now active for the Holidays! Boar Gifts are more frequent from Powerup Events, there's new boars to obtain, and Boar Gifts have improved odds for getting rarer boars!"
     ],
     "notificationServerPing": "<@&1001233916620972082> \n*Note: If you run /boar daily a second time, then click \"Enable Notifications\", you can receive your notifications in DMs instead. To disable this ping, un-react to the boar emoji in <#996887892737667204>*",
     "questCompletionBonus": "Full Completion Bonus:",
@@ -326,7 +327,7 @@
     "maxStreak": 99999999,
     "maxDailies": 99999999,
     "maxIndivBoars": 100000000000000000,
-    "maxPowBase": 99999999999999999,
+    "maxPowBase": 100000000000000000,
     "maxEnhancers": 30,
     "maxSmallPow": 999999999,
     "maxPowPages": 3,
@@ -1041,6 +1042,7 @@
     "marketOrdClaimWidth": 620,
     "marketRange": 2,
     "orderExpire": 604800000,
+    "openDelay": 120000,
     "notificationButtonDelay": 15000,
     "questFullAmt": 3,
     "questImgSize": [
@@ -2370,19 +2372,19 @@
       "valType": "rarity",
       "questVals": [
         [
-          2,
+          3,
           2
         ],
         [
-          3,
+          4,
           3
         ],
         [
-          4,
+          5,
           1
         ],
         [
-          5,
+          6,
           1
         ]
       ]
@@ -2470,19 +2472,19 @@
       "valType": "rarity",
       "questVals": [
         [
-          2,
+          3,
           3
         ],
         [
-          3,
+          4,
           5
         ],
         [
-          4,
+          5,
           1
         ],
         [
-          5,
+          6,
           1
         ]
       ]
@@ -2538,8 +2540,8 @@
       ]
     },
     "powParticipate": {
-      "description": "Participate in %@ Powerup Event",
-      "descriptionAlt": "Participate in %@ Powerup Events",
+      "description": "Succeed in %@ Powerup Event",
+      "descriptionAlt": "Succeed in %@ Powerup Events",
       "lowerReward": "bucks",
       "higherReward": "enhancer",
       "valType": "number",
@@ -2622,6 +2624,13 @@
         "description": "Zombification is impossible for boars, so this boar is actually just a cannibal in a costume. Still frightening either way.",
         "isSB": false
       },
+      "ice": {
+        "name": "Icy Boar",
+        "pluralName": "Icy Boars",
+        "file": "IceBoar.png",
+        "description": "Touching this boar will instantly give you frostbite. Wherever it goes, blizzard-like conditions follow. Found in the heart of glaciers.",
+        "isSB": false
+      },
       "normal": {
         "name": "Normal Boar",
         "pluralName": "Normal Boars",
@@ -2693,6 +2702,13 @@
         "file": "Boarnderwear.png",
         "description": "Children all around the world are disappointed when they open a gift excitedly just to get this boar. It appears as though it's been worn.",
         "isSB": false
+      },
+      "santa": {
+        "name": "Santa Boar",
+        "pluralName": "Santa Boars",
+        "file": "SantaBoar.png",
+        "description": "Every Boarmas, this boar delivers gifts to both young and old! Questioning its identity is highly discouraged.",
+        "isSB": false
       }
     },
     "badges": {
@@ -2729,9 +2745,18 @@
         "rewardAmt": 1,
         "outcomes": [
           {
-            "weight": 1,
+            "weight": 10,
             "category": "Special Boar",
-            "suboutcomes": []
+            "suboutcomes": [
+              {
+                "weight": 9,
+                "name": "santa"
+              },
+              {
+                "weight": 1,
+                "name": "underwear"
+              }
+            ]
           },
           {
             "weight": 800,
@@ -2752,7 +2777,7 @@
             ]
           },
           {
-            "weight": 399,
+            "weight": 392,
             "category": "Powerups",
             "suboutcomes": [
               {
@@ -2798,7 +2823,7 @@
     {
       "name": "Wicked",
       "pluralName": "Wickeds",
-      "weight": 826,
+      "weight": 827,
       "baseScore": 20,
       "fromDaily": false,
       "hunterNeed": false,
@@ -2807,6 +2832,20 @@
       "avgClones": 100,
       "boars": [
         "zombie"
+      ]
+    },
+    {
+      "name": "Festive",
+      "pluralName": "Festives",
+      "weight": 826,
+      "baseScore": 20,
+      "fromDaily": false,
+      "hunterNeed": false,
+      "givesSpecial": false,
+      "enhancersNeeded": 0,
+      "avgClones": 100,
+      "boars": [
+        "ice"
       ]
     },
     {
@@ -2923,6 +2962,7 @@
     },
     {
       "name": "Special",
+      "pluralName": "Specials",
       "weight": 0,
       "baseScore": 0,
       "fromDaily": false,
@@ -2950,14 +2990,15 @@
     "maintenance": "#FFFF00",
     "error": "#FF5555",
     "rarity1": "#474747,#679311,#474747",
-    "rarity2": "#FFFFFF",
-    "rarity3": "#00FF0F",
-    "rarity4": "#0064FF",
-    "rarity5": "#6400FF",
-    "rarity6": "#FFC500",
-    "rarity7": "#F300FF",
-    "rarity8": "#00FFFB",
-    "rarity9": "#ff6666,#ffb566,#fffa66,#74ff66,#666bff,#b966ff",
-    "rarity10": "#BC2326,#FF3136,#BC2326"
+    "rarity2": "#ff0000,#ffffff,#155412",
+    "rarity3": "#FFFFFF",
+    "rarity4": "#00FF0F",
+    "rarity5": "#0064FF",
+    "rarity6": "#6400FF",
+    "rarity7": "#FFC500",
+    "rarity8": "#F300FF",
+    "rarity9": "#00FFFB",
+    "rarity10": "#ff6666,#ffb566,#fffa66,#74ff66,#666bff,#b966ff",
+    "rarity11": "#BC2326,#FF3136,#BC2326"
   }
 }

--- a/src/main/js/bot/BoarBot.ts
+++ b/src/main/js/bot/BoarBot.ts
@@ -260,15 +260,21 @@ export class BoarBot implements Bot {
 							break;
 						}
 
-						case 20: {
+						case 20:
+						case 21: {
 							randMsgStr = msgStrs[0];
 							break;
 						}
 					}
 
 					const curDate = new Date();
+
 					if (curDate.getMonth() === 9 && curDate.getDate() >= 24) {
 						randMsgStr = '## ' + msgStrs[20] + '\n';
+					}
+
+					if (curDate.getMonth() === 11 && curDate.getDate() >= 22) {
+						randMsgStr = '## ' + msgStrs[21] + '\n';
 					}
 
 					const notificationChannelID = boarUser.stats.general.notificationChannel

--- a/src/main/js/bot/config/NumberConfig.ts
+++ b/src/main/js/bot/config/NumberConfig.ts
@@ -46,6 +46,7 @@ export class NumberConfig {
 
     public readonly collectorIdle = 0 as number;
     public readonly orderExpire = 0 as number;
+    public readonly openDelay = 0 as number; // Cooldown for opening gifts
     public readonly oneDay = 0 as number;
     public readonly notificationButtonDelay = 0 as number;
 

--- a/src/main/js/bot/data/user/collectibles/CollectedPowerup.ts
+++ b/src/main/js/bot/data/user/collectibles/CollectedPowerup.ts
@@ -13,6 +13,7 @@ export class CollectedPowerup {
     public numActive?: number; // For miracle charms
     public numOpened?: number; // For gifts
     public curOut?: number; // For gifts
+    public lastOpened?: number; // For gifts
     public numSuccess?: number; // For clones
     public raritiesUsed?: number[]; // For clones and transmutations
 }

--- a/src/main/js/commands/boar/CollectionSubcommand.ts
+++ b/src/main/js/commands/boar/CollectionSubcommand.ts
@@ -424,7 +424,8 @@ export default class CollectionSubcommand implements Subcommand {
         // The boar user will get if transmutation is successful
         const enhancedBoar = BoarUtils.findValid(this.allBoars[this.curPage].rarity[0], this.guildData, this.config);
 
-        if (enhancedBoar === '' || this.allBoars[this.curPage].rarity[0] >= 9) {
+        // Disallow 3rd highest rarity and higher from being enhanced if bypassed
+        if (enhancedBoar === '' || this.allBoars[this.curPage].rarity[0] >= this.config.rarityConfigs.length - 2) {
             await LogDebug.handleError(this.config.stringConfig.dailyNoBoarFound, this.firstInter);
             return;
         }
@@ -461,7 +462,7 @@ export default class CollectionSubcommand implements Subcommand {
                 this.boarUser.stats.general.totalBoars--;
                 this.boarUser.itemCollection.powerups.enhancer.numTotal = 0;
                 (this.boarUser.itemCollection.powerups.enhancer.raritiesUsed as number[])[
-                    this.allBoars[this.curPage].rarity[0]-2
+                    this.allBoars[this.curPage].rarity[0]-3
                 ]++;
                 this.boarUser.stats.quests.progress[spendBucksIndex] += enhancersNeeded * 5;
 

--- a/src/main/js/commands/boar/DailySubcommand.ts
+++ b/src/main/js/commands/boar/DailySubcommand.ts
@@ -99,7 +99,7 @@ export default class DailySubcommand implements Subcommand {
                 }
 
                 // Adjusts weights in accordance to multiplier
-                rarityWeights = this.applyMultiplier(userMultiplier, rarityWeights);
+                rarityWeights = BoarUtils.applyMultiplier(userMultiplier, rarityWeights, this.config);
 
                 const hasAllTruths = boarUser.stats.general.truths &&
                     !boarUser.stats.general.truths.includes(false);
@@ -379,45 +379,5 @@ export default class DailySubcommand implements Subcommand {
         });
 
         return false;
-    }
-
-    /**
-     * Applies the user multiplier to rarity weights using an arc-tan function
-     *
-     * @param userMultiplier - Used to increase weight
-     * @param rarityWeights - Map of weights and their indexes
-     * @private
-     */
-    private applyMultiplier(userMultiplier: number, rarityWeights: Map<number, number>): Map<number, number> {
-        // Sorts from the highest weight to the lowest weight
-        const newWeights = new Map<number, number>(
-            [...rarityWeights.entries()].sort((a: [number, number], b: [number, number]) => {
-                return b[1] - a[1];
-            })
-        );
-
-        const highestWeight = newWeights.values().next().value;
-        const rarityIncreaseConst =
-            this.config.numberConfig.rarityIncreaseConst;
-
-        // Increases probability by increasing weight
-        // https://www.desmos.com/calculator/74inrkixxa | x = multiplier, o = weight
-        for (const weightInfo of newWeights) {
-            const rarityIndex = weightInfo[0];
-            const oldWeight = weightInfo[1];
-
-            if (oldWeight == 0) continue;
-
-            newWeights.set(
-                rarityIndex,
-                oldWeight * (Math.atan(((userMultiplier - 1) * oldWeight) / rarityIncreaseConst) *
-                    (highestWeight - oldWeight) / oldWeight + 1)
-            );
-        }
-
-        // Restores the original order of the Map
-        return new Map([...newWeights.entries()].sort((a: [number, number], b: [number, number]) => {
-            return a[0] - b[0];
-        }));
     }
 }

--- a/src/main/js/commands/boar/MarketSubcommand.ts
+++ b/src/main/js/commands/boar/MarketSubcommand.ts
@@ -548,8 +548,8 @@ export default class MarketSubcommand implements Subcommand {
             );
 
             LogDebug.log(
-                `!! ${isSell ? 'SELL' : 'BUY'} ORDER CLAIMED!! - ${orderInfo.id} ` +
-                    `(${orderInfo.data.claimedAmount}/${orderInfo.data.num}, $${orderInfo.data.price})`,
+                `!!${isSell ? 'SELL' : 'BUY'} ORDER CLAIMED!! - ${orderInfo.id} ` +
+                    `(${orderInfo.data.claimedAmount + numToClaim}/${orderInfo.data.num}, $${orderInfo.data.price})`,
                 this.config,
                 this.firstInter,
                 true
@@ -845,7 +845,7 @@ export default class MarketSubcommand implements Subcommand {
             this.boarUser.itemCollection.boars[orderInfo.id].num += numToReturn;
 
             const canCollectBoarQuest = collectBoarIndex >= 0 && isClaim &&
-                Math.floor(collectBoarIndex / 2) + 2 === BoarUtils.findRarity(orderInfo.id, this.config)[0];
+                Math.floor(collectBoarIndex / 2) + 3 === BoarUtils.findRarity(orderInfo.id, this.config)[0];
 
             // Counts progress toward collecting boar rarity quest if claiming a boar buy order
             if (canCollectBoarQuest) {
@@ -1026,9 +1026,11 @@ export default class MarketSubcommand implements Subcommand {
 
                                     const filledAmt = newItemData.sellers[curIndex].filledAmount;
                                     const ordAmt = newItemData.sellers[curIndex].num;
+                                    const isExpired = newItemData.sellers[curIndex].listTime +
+                                        this.config.numberConfig.orderExpire < Date.now();
 
                                     // Gets price of order and ID of user that made order for logging
-                                    if (filledAmt !== ordAmt) {
+                                    if (filledAmt !== ordAmt && !isExpired) {
                                         prices += '$' + newItemData.sellers[curIndex].price + ' ';
                                         userIDs += newItemData.sellers[curIndex].userID + ' ';
                                     }
@@ -1208,7 +1210,7 @@ export default class MarketSubcommand implements Subcommand {
                         }
 
                         const canCollectBoarQuest = collectBoarIndex >= 0 && !isOwnOrder &&
-                            Math.floor(collectBoarIndex / 2) + 2 === BoarUtils.findRarity(itemData.id, this.config)[0];
+                            Math.floor(collectBoarIndex / 2) + 3 === BoarUtils.findRarity(itemData.id, this.config)[0];
 
                         // Counts progress toward collect boar quest
                         if (canCollectBoarQuest) {
@@ -1288,12 +1290,8 @@ export default class MarketSubcommand implements Subcommand {
 
                                 // Attempts to grab price of all items combined across orders
                                 while (numGrabbed < this.modalData[0]) {
-                                    if (curIndex >= newItemData.buyers.length) break;
-
-                                    let numToAdd = 0;
-
                                     // Adds amount left in current order or amount left to satisfy insta sell
-                                    numToAdd = Math.min(
+                                    const numToAdd = Math.min(
                                         this.modalData[0] - numGrabbed,
                                         newItemData.buyers[curIndex].listTime + nums.orderExpire < Date.now()
                                             ? 0
@@ -1306,9 +1304,11 @@ export default class MarketSubcommand implements Subcommand {
 
                                     const filledAmt = newItemData.buyers[curIndex].filledAmount;
                                     const numAmt = newItemData.buyers[curIndex].num;
+                                    const isExpired = newItemData.buyers[curIndex].listTime +
+                                        this.config.numberConfig.orderExpire < Date.now();
 
                                     // Gets price of order and ID of user that made order for logging
-                                    if (filledAmt !== numAmt) {
+                                    if (filledAmt !== numAmt && !isExpired) {
                                         prices += '$' + newItemData.buyers[curIndex].price + ' ';
                                         userIDs += newItemData.buyers[curIndex].userID + ' ';
                                     }
@@ -1469,7 +1469,7 @@ export default class MarketSubcommand implements Subcommand {
 
                     if (!failedSale) {
                         LogDebug.log(
-                            `!!INSTANT SELL!! ${this.modalData[0]} of ${itemData.id} for ${prices.trim()} from `+
+                            `!!INSTANT SELL!! ${this.modalData[0]} of ${itemData.id} for ${prices.trim()} to `+
                                 `${userIDs.trim()}`,
                             this.config,
                             inter,

--- a/src/main/js/commands/boar_manage/SetupSubcommand.ts
+++ b/src/main/js/commands/boar_manage/SetupSubcommand.ts
@@ -348,7 +348,7 @@ export default class SetupSubcommand implements Subcommand {
                     break;
                 case CollectorUtils.Reasons.Finished:
                     LogDebug.log(
-                        `${this.firstInter.guild?.id} had BoarBot set up by ` +
+                        `${this.firstInter.guild?.name} (${this.firstInter.guild?.id}) had BoarBot set up by ` +
                             `${this.firstInter.user.username} (${this.firstInter.user.id})`,
                         this.config,
                         undefined,

--- a/src/main/js/feat/PowerupEvent.ts
+++ b/src/main/js/feat/PowerupEvent.ts
@@ -473,7 +473,17 @@ export class PowerupEvent {
         const powerups = config.itemConfigs.powerups;
         const powerupIDs = Object.keys(powerups);
 
-        let powerupID = powerupIDs[Math.floor(Math.random() * powerupIDs.length)];
+        let powerupID: string;
+        const curDate = new Date();
+        const isFestiveWeek = curDate.getMonth() === 11 && curDate.getDate() >= 24;
+
+        // If it's festive week, ~86.66% of Powerup Events will give gifts
+        if (isFestiveWeek && Math.random() < .8) {
+            powerupID = 'gift';
+            return powerupID
+        }
+
+        powerupID = powerupIDs[Math.floor(Math.random() * powerupIDs.length)];
         while (powerupID === 'enhancer') {
             powerupID = powerupIDs[Math.floor(Math.random() * powerupIDs.length)];
         }

--- a/src/main/js/util/boar/BoarUser.ts
+++ b/src/main/js/util/boar/BoarUser.ts
@@ -115,8 +115,8 @@ export class BoarUser {
 
         const cloneRaritiesNew = userData.itemCollection.powerups.clone.raritiesUsed as number[];
         const cloneRarities = this.itemCollection.powerups.clone.raritiesUsed as number[];
-        this.stats.quests.progress[cloneRarityIndex] += cloneRarities[Math.floor(cloneRarityIndex / 2) + 1] -
-            cloneRaritiesNew[Math.floor(cloneRarityIndex / 2) + 1];
+        this.stats.quests.progress[cloneRarityIndex] += cloneRarities[Math.floor(cloneRarityIndex / 2) + 2] -
+            cloneRaritiesNew[Math.floor(cloneRarityIndex / 2) + 2];
 
         this.stats.quests.progress[sendGiftsIndex] += this.itemCollection.powerups.gift.numUsed -
             userData.itemCollection.powerups.gift.numUsed;
@@ -253,11 +253,17 @@ export class BoarUser {
         if (!this.itemCollection.powerups.clone) {
             this.itemCollection.powerups.clone = new CollectedPowerup();
             this.itemCollection.powerups.clone.numSuccess = 0;
-            this.itemCollection.powerups.clone.raritiesUsed = [0,0,0,0,0,0,0,0,0];
+            this.itemCollection.powerups.clone.raritiesUsed = [0,0,0,0,0,0,0,0,0,0];
         }
+
+        // TODO: Write a script that goes through all users and fixes this
 
         if ((this.itemCollection.powerups.clone.raritiesUsed as number[]).length === 7) {
             (this.itemCollection.powerups.clone.raritiesUsed as number[]).push(0);
+            (this.itemCollection.powerups.clone.raritiesUsed as number[]).unshift(0);
+        }
+
+        if ((this.itemCollection.powerups.clone.raritiesUsed as number[]).length === 9) {
             (this.itemCollection.powerups.clone.raritiesUsed as number[]).unshift(0);
         }
 
@@ -453,7 +459,7 @@ export class BoarUser {
                         ? scores[i]
                         : 0;
 
-                    if (collectBoarIndex >= 0 && Math.floor(collectBoarIndex / 2) + 2 === rarityInfos[i][0]) {
+                    if (collectBoarIndex >= 0 && Math.floor(collectBoarIndex / 2) + 3 === rarityInfos[i][0]) {
                         this.stats.quests.progress[collectBoarIndex]++;
                     }
 

--- a/src/main/js/util/generators/CollectionImageGenerator.ts
+++ b/src/main/js/util/generators/CollectionImageGenerator.ts
@@ -761,12 +761,12 @@ export class CollectionImageGenerator {
             if (i < 3) {
                 await CanvasUtils.drawText(
                     ctx, strConfig.collEnhancedLabel, nums.collEnhancedLabelPositions[i], mediumFont, 'center',
-                    colorConfig.font, undefined, false, [rarityConfig[i+1].pluralName], [colorConfig['rarity' + (i+2)]]
+                    colorConfig.font, undefined, false, [rarityConfig[i+2].pluralName], [colorConfig['rarity' + (i+3)]]
                 );
             } else {
                 await CanvasUtils.drawText(
-                    ctx, rarityConfig[i+1].pluralName, nums.collEnhancedLabelPositions[i],
-                    mediumFont, 'center', colorConfig['rarity' + (i+2)]
+                    ctx, rarityConfig[i+2].pluralName, nums.collEnhancedLabelPositions[i],
+                    mediumFont, 'center', colorConfig['rarity' + (i+3)]
                 );
             }
 


### PR DESCRIPTION
## Boarmas Changes
- Notification during week of Boarmas describe what Boarmas is
- Santa Boar is a 1/250 chance to get from Boar Gifts during Boarmas (Giver gets lower edition)
- Boarnderwear chances increased by 2x during Boarmas
- Boars from Boar Gifts are rolled as if 50 Boar Blessings were applied during Boarmas
- Added Festive rarity, only obtained during Boarmas
- Powerup Events have a ~86.66% chance of being Boar Gifts during Boarmas

## Other Changes
- Fixed Boar Gifts being slow to open with more than one person interacting
- Added a 2-minute cooldown to opening Boar Gifts
- Changed the wording when you guess incorrectly in a Powerup Event
- Changed wording of a powerup quest from "participate" to "succeed"

## Dev Changes
- Fixed some logs still being incorrect
