### PR TITLE
Added santa to specials list in config

### DIFF
--- a/example_config.json
+++ b/example_config.json
@@ -2972,7 +2972,8 @@
       "enhancersNeeded": 0,
       "boars": [
         "bacteria",
-        "underwear"
+        "underwear",
+        "santa"
       ]
     }
   ],


### PR DESCRIPTION
Santa Boar cannot be obtained otherwise and will instead error out.