### PR TITLE
Fixed full quest claim not resetting

### DIFF
--- a/database.sql
+++ b/database.sql
@@ -641,7 +641,8 @@ begin
         six_progress = 0,
         six_claimed = 0,
         seven_progress = 0,
-        seven_claimed = 0;
+        seven_claimed = 0,
+        full_claimed = 0;
     
     UPDATE users
     SET quest_bless = 0;


### PR DESCRIPTION
Quest bonus would not reset every week. This change fixes that. Closes #9.