### PR TITLE
Fix Going Back Going to Wrong Boar From Editions View

### DIFF
--- a/src/main/java/dev/boarbot/interactives/boar/megamenu/MegaMenuComponentHandler.java
+++ b/src/main/java/dev/boarbot/interactives/boar/megamenu/MegaMenuComponentHandler.java
@@ -175,7 +175,7 @@ class MegaMenuComponentHandler implements Configured {
                     String boarID = this.interactive.curBoarEntry.getKey();
 
                     if (this.interactive.filteredBoars.containsKey(boarID)) {
-                        this.interactive.boarPage = this.interactive.curBoarEntry.getKey();
+                        this.interactive.boarPage = BOARS.get(this.interactive.curBoarEntry.getKey()).getName();
                     } else {
                         this.interactive.page = 0;
                     }


### PR DESCRIPTION
When leaving the Editions View, it would try to bring you back to your previous boar via ID instead of by name, leading to unexpected and strange behavior. This PR fixes that issue. See #44 

This PR also updates the config file with some changes to search terms.