### PR TITLE
Fix Bot Crash on Daily Reset

### DIFF
--- a/src/main/java/dev/boarbot/interactives/boar/megamenu/MegaMenuComponentsGetter.java
+++ b/src/main/java/dev/boarbot/interactives/boar/megamenu/MegaMenuComponentsGetter.java
@@ -259,6 +259,12 @@ class MegaMenuComponentsGetter implements Configured {
     private ActionRow[] getAdventComponents() {
         ActionRow[] nav = this.getNav();
 
+        boolean userSelf = this.interactive.getUser().getId().equals(this.interactive.getBoarUser().getUserID());
+
+        if (!userSelf) {
+            return nav;
+        }
+
         List<ItemComponent> claimBtnRow = InteractiveUtil.makeComponents(
             this.interactive.getInteractionID(), COMPONENTS.get("adventClaimBtn")
         );

--- a/src/main/java/dev/boarbot/interactives/boar/megamenu/MegaMenuGeneratorMaker.java
+++ b/src/main/java/dev/boarbot/interactives/boar/megamenu/MegaMenuGeneratorMaker.java
@@ -278,7 +278,7 @@ class MegaMenuGeneratorMaker implements Configured {
             return this.make();
         }
 
-        this.interactive.maxPage = 0;
+        this.interactive.maxPage = this.interactive.getBadges().size()-1;
         if (this.interactive.page > this.interactive.maxPage) {
             this.interactive.page = this.interactive.maxPage;
         }
@@ -325,7 +325,7 @@ class MegaMenuGeneratorMaker implements Configured {
             }
         }
 
-        this.interactive.maxPage = this.interactive.getBadges().size()-1;
+        this.interactive.maxPage = 0;
         if (this.interactive.page > this.interactive.maxPage) {
             this.interactive.page = this.interactive.maxPage;
         }

--- a/src/main/java/dev/boarbot/jobs/CooldownFixJob.java
+++ b/src/main/java/dev/boarbot/jobs/CooldownFixJob.java
@@ -1,0 +1,27 @@
+package dev.boarbot.jobs;
+
+import dev.boarbot.util.interaction.InteractionUtil;
+import dev.boarbot.util.time.TimeUtil;
+import lombok.Getter;
+import org.quartz.*;
+
+public class CooldownFixJob implements Job {
+    @Getter private final static JobDetail job = JobBuilder.newJob(CooldownFixJob.class).build();
+    @Getter private final static Trigger trigger = TriggerBuilder.newTrigger()
+        .withSchedule(CronScheduleBuilder.cronSchedule("*/10 * * ? * *")).build();
+
+    private final static int COOLDOWN_SLEEP_TIME = 3000;
+
+    @Override
+    public void execute(JobExecutionContext context) throws JobExecutionException {
+        if (InteractionUtil.usersOnCooldown.isEmpty()) {
+            return;
+        }
+
+        for (String user : InteractionUtil.usersOnCooldown.keySet()) {
+            if (InteractionUtil.usersOnCooldown.get(user) < TimeUtil.getCurMilli() - COOLDOWN_SLEEP_TIME) {
+                InteractionUtil.usersOnCooldown.remove(user);
+            }
+        }
+    }
+}

--- a/src/main/java/dev/boarbot/jobs/JobScheduler.java
+++ b/src/main/java/dev/boarbot/jobs/JobScheduler.java
@@ -27,6 +27,7 @@ public class JobScheduler {
             scheduler.scheduleJob(
                 BlessResetJob.getJob(), Set.of(BlessResetJob.getTrigger1(), BlessResetJob.getTrigger2()), true
             );
+            scheduler.scheduleJob(CooldownFixJob.getJob(), CooldownFixJob.getTrigger());
 
             scheduler.scheduleJob(
                 SpookMessageJob.getJob(),

--- a/src/main/java/dev/boarbot/util/generators/ItemImageGenerator.java
+++ b/src/main/java/dev/boarbot/util/generators/ItemImageGenerator.java
@@ -158,7 +158,7 @@ public class ItemImageGenerator extends ImageGenerator {
         return this;
     }
 
-    private void generateAnimated() throws IOException {
+    private void generateAnimated() throws IOException, URISyntaxException {
         Gson g = new Gson();
 
         byte[] animatedImage = GraphicsUtil.getImageBytes(this.filePath);

--- a/src/main/java/dev/boarbot/util/generators/OverlayImageGenerator.java
+++ b/src/main/java/dev/boarbot/util/generators/OverlayImageGenerator.java
@@ -55,19 +55,19 @@ public class OverlayImageGenerator extends ImageGenerator {
 
     public OverlayImageGenerator(
         BufferedImage image, String path, int[] size, boolean darken
-    ) throws IOException {
+    ) throws IOException, URISyntaxException {
         this(image, path, size, null, darken);
     }
 
     public OverlayImageGenerator(
         BufferedImage image, String path, int[] size, int[] pos
-    ) throws IOException {
+    ) throws IOException, URISyntaxException {
         this(image, path, size, pos, true);
     }
 
     public OverlayImageGenerator(
         BufferedImage image, String path, int[] size, int[] pos, boolean darken
-    ) throws IOException {
+    ) throws IOException, URISyntaxException {
         this.generatedImage = image;
         this.animatedImage = GraphicsUtil.getImageBytes(path);
         this.animated = true;

--- a/src/main/java/dev/boarbot/util/graphics/GraphicsUtil.java
+++ b/src/main/java/dev/boarbot/util/graphics/GraphicsUtil.java
@@ -5,6 +5,7 @@ import dev.boarbot.util.resource.ResourceUtil;
 import javax.imageio.ImageIO;
 import java.awt.*;
 import java.awt.geom.RoundRectangle2D;
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
@@ -58,20 +59,21 @@ public final class GraphicsUtil {
     }
 
     public static Image getImage(String path) throws URISyntaxException, IOException {
-        Image image;
-
-        if (path.startsWith("http")) {
-            image = ImageIO.read(new URI(path).toURL());
-        } else {
-            image = ImageIO.read(ResourceUtil.getResource(path));
-        }
-
-        return image;
+        return ImageIO.read(new ByteArrayInputStream(getImageBytes(path)));
     }
 
-    public static byte[] getImageBytes(String path) throws IOException {
-        InputStream is = ResourceUtil.getResourceStream(path);
-        return is.readAllBytes();
+    public static byte[] getImageBytes(String path) throws IOException, URISyntaxException {
+        InputStream stream;
+
+        if (path.startsWith("http")) {
+            stream = new URI(path).toURL().openStream();
+        } else {
+            stream = ResourceUtil.getResourceStream(path);
+        }
+
+        try (InputStream is = stream) {
+            return is.readAllBytes();
+        }
     }
 
     public static void drawCircleImage(

--- a/src/main/java/dev/boarbot/util/interaction/InteractionUtil.java
+++ b/src/main/java/dev/boarbot/util/interaction/InteractionUtil.java
@@ -58,7 +58,7 @@ public class InteractionUtil {
         }
 
         usersOnCooldown.put(user.getId(), TimeUtil.getCurMilli());
-        //sscheduler.schedule(() -> usersOnCooldown.remove(user.getId()), COOLDOWN_SLEEP_TIME, TimeUnit.MILLISECONDS);
+        scheduler.schedule(() -> usersOnCooldown.remove(user.getId()), COOLDOWN_SLEEP_TIME, TimeUnit.MILLISECONDS);
 
         return false;
     }

--- a/src/main/resources/config/game/rarities.json
+++ b/src/main/resources/config/game/rarities.json
@@ -6,7 +6,7 @@
     "baseBucks": 20,
     "researcherNeed": true,
     "givesFirstBoar": true,
-    "avgClones": 100,
+    "avgClones": 1000,
     "targetStock": 5,
     "priceAdjustWaitHours": 552,
     "boars": [
@@ -20,7 +20,7 @@
     "baseBucks": 20,
     "researcherNeed": true,
     "givesFirstBoar": true,
-    "avgClones": 100,
+    "avgClones": 1000,
     "targetStock": 5,
     "priceAdjustWaitHours": 552,
     "boars": [

--- a/src/main/resources/config/game/rarities.json
+++ b/src/main/resources/config/game/rarities.json
@@ -8,7 +8,7 @@
     "givesFirstBoar": true,
     "avgClones": 100,
     "targetStock": 5,
-    "priceAdjustWaitHours": 336,
+    "priceAdjustWaitHours": 552,
     "boars": [
       "ghost"
     ]
@@ -22,7 +22,7 @@
     "givesFirstBoar": true,
     "avgClones": 100,
     "targetStock": 5,
-    "priceAdjustWaitHours": 336,
+    "priceAdjustWaitHours": 552,
     "boars": [
       "ice"
     ]
@@ -35,7 +35,7 @@
     "researcherNeed": true,
     "avgClones": 100,
     "targetStock": 5,
-    "priceAdjustWaitHours": 336,
+    "priceAdjustWaitHours": 552,
     "boars": [
       "birthday"
     ]
@@ -51,7 +51,7 @@
     "chargesNeeded": 1,
     "avgClones": 1,
     "targetStock": 50,
-    "priceAdjustWaitHours": 12,
+    "priceAdjustWaitHours": 24,
     "boars": [
       "normal"
     ]
@@ -67,7 +67,7 @@
     "chargesNeeded": 2,
     "avgClones": 2,
     "targetStock": 30,
-    "priceAdjustWaitHours": 24,
+    "priceAdjustWaitHours": 48,
     "boars": [
       "carrot"
     ]
@@ -83,7 +83,7 @@
     "chargesNeeded": 3,
     "avgClones": 5,
     "targetStock": 20,
-    "priceAdjustWaitHours": 48,
+    "priceAdjustWaitHours": 72,
     "boars": [
       "sphere"
     ]
@@ -99,7 +99,7 @@
     "chargesNeeded": 5,
     "avgClones": 10,
     "targetStock": 15,
-    "priceAdjustWaitHours": 72,
+    "priceAdjustWaitHours": 120,
     "boars": [
       "creepy"
     ]
@@ -116,7 +116,7 @@
     "chargesNeeded": 10,
     "avgClones": 20,
     "targetStock": 10,
-    "priceAdjustWaitHours": 96,
+    "priceAdjustWaitHours": 192,
     "boars": [
       "minimumwage"
     ]
@@ -132,7 +132,7 @@
     "chargesNeeded": 18,
     "avgClones": 50,
     "targetStock": 5,
-    "priceAdjustWaitHours": 120,
+    "priceAdjustWaitHours": 288,
     "boars": [
       "cowboy"
     ]
@@ -148,7 +148,7 @@
     "chargesNeeded": 30,
     "avgClones": 200,
     "targetStock": 3,
-    "priceAdjustWaitHours": 144,
+    "priceAdjustWaitHours": 408,
     "boars": [
       "rickroll"
     ]
@@ -163,7 +163,7 @@
     "showEdition": true,
     "avgClones": 500,
     "targetStock": 1,
-    "priceAdjustWaitHours": 240,
+    "priceAdjustWaitHours": 552,
     "boars": [
       "supernova"
     ]

--- a/src/main/resources/config/game/rarities.json
+++ b/src/main/resources/config/game/rarities.json
@@ -33,7 +33,7 @@
     "weight": 0,
     "baseBucks": 20,
     "researcherNeed": true,
-    "avgClones": 100,
+    "avgClones": 1000,
     "targetStock": 5,
     "priceAdjustWaitHours": 552,
     "boars": [

--- a/src/main/resources/config/lang/en_us.json
+++ b/src/main/resources/config/lang/en_us.json
@@ -252,7 +252,7 @@
     "There are <>green<>3<>font<> rarities that only appear during certain times of the year. <br> <br>",
     "<>halloween<>Haunting<>font<> - Replaces Common Boars during <>halloween<>Boar-O-Ween<>font<>. Newest are only obtainable from <>halloween<>Boar-O-Ween<>font<> hunts. (<>green<>%,d<>font<>) <br> <br>",
     "<>christmas<>Festive<>font<> - Replaces Common Boars during <>christmas<>Boarmas<>font<>. (<>green<>%,d<>font<>) <br> <br>",
-    "<>event<>Event<>font<> - Currently only obtainable on BoarBot's anniversary on <>green<>June 30th<>font<>. This rarity is a catch-all for boars only obtainable at certain times. (<>green<>%,d<>font<>) <br> <br>",
+    "<>event<>Event<>font<> - This rarity is a catch-all for boars only obtainable at certain times, such as anniversaries, holiday events, and hunts. (<>green<>%,d<>font<>) <br> <br>",
     "<>halloween<>Haunting<>font<> and <>christmas<>Festive<>font<> are very heavily aligned with the western holidays Halloween and Christmas. We apologize to non-observers."
   ],
   "helpBadge1HL": "What are Badges?",

--- a/src/main/resources/config/lang/en_us.json
+++ b/src/main/resources/config/lang/en_us.json
@@ -310,7 +310,7 @@
     "<>mythic<>Mythic<>font<>: <>green<>1/50 <br>",
     "<>divine<>Divine<>font<>: <>green<>1/200 <br>",
     "<>immaculate<>Immaculate<>font<>: <>green<>1/500 <br>",
-    "<>halloween<>Haunting<>font<>/<>christmas<>Festive<>font<>/<>event<>Event<>font<>: <>green<>1/100 <br> <br>",
+    "<>halloween<>Haunting<>font<>/<>christmas<>Festive<>font<>/<>event<>Event<>font<>: <>green<>1/1000 <br> <br>",
     "<>font<>These can be used from <>silver<>/boar compendium<>font<>. <br> <br>",
     "This <>powerup<>powerup<>font<>'s main purpose is to increase the amount of newly made boars in the economy."
   ],


### PR DESCRIPTION
## Bug Fixes
- Fixed an issue where many people running /boar advent at once would lock the bot up
- Fixed the possibility of being on cooldown until the bot restarts

## Changes
- Holiday Boars and Event boars avgClone value increased from 100 -> 1000