### PR TITLE
Improve Boar Streak Loss & Fix Boar Gift Handicap

### DIFF
--- a/src/main/java/dev/boarbot/entities/boaruser/queries/BaseQueries.java
+++ b/src/main/java/dev/boarbot/entities/boaruser/queries/BaseQueries.java
@@ -132,7 +132,7 @@ public class BaseQueries implements Configured {
 
         while (timeToReach < curTimeCheck) {
             if (newBoarStreak > 0) {
-                int curRemove = (int) Math.pow(7, curDailiesMissed + newDailiesMissed);
+                int curRemove = (int) Math.pow(7, (curDailiesMissed + newDailiesMissed) * 0.4);
                 newBoarStreak = Math.max(newBoarStreak - curRemove, 0);
             }
 

--- a/src/main/java/dev/boarbot/entities/boaruser/queries/BaseQueries.java
+++ b/src/main/java/dev/boarbot/entities/boaruser/queries/BaseQueries.java
@@ -132,7 +132,7 @@ public class BaseQueries implements Configured {
 
         while (timeToReach < curTimeCheck) {
             if (newBoarStreak > 0) {
-                int curRemove = (int) Math.pow(7, (curDailiesMissed + newDailiesMissed) * 0.4);
+                int curRemove = (int) Math.pow(2, curDailiesMissed + newDailiesMissed);
                 newBoarStreak = Math.max(newBoarStreak - curRemove, 0);
             }
 

--- a/src/main/java/dev/boarbot/interactives/gift/BoarGiftInteractive.java
+++ b/src/main/java/dev/boarbot/interactives/gift/BoarGiftInteractive.java
@@ -364,7 +364,7 @@ public class BoarGiftInteractive extends UserInteractive implements Synchronizab
                        boarUser.giftQuery().getGiftHandicap(connection);
 
                     Log.debug(this.user, this.getClass(), "Handicapped Value: %,d".formatted(userVal));
-                    if (userVal > this.giftWinnerValue) {
+                    if (userVal < this.giftWinnerValue) {
                         this.giftWinner = boarUser.getUser();
                         this.giftWinnerValue = userVal;
                         Log.info(


### PR DESCRIPTION
## Bug Fixes
- Boar Gift winner is now set to the best time instead of the worst time (pain)

## Changes
- Boar Streak is now lost at a rate of 2^(consecutive days missed)
  - Missing 1 day = 1 streak lost
  - Missing 2 days = 1 + 2 = 3 streak lost
  - Missing 3 days = 1 + 2 + 4 = 7 streak lost
  - Missing 7 days = 1 + 2 + 4 + 8 + 16 + 32 + 64 = 127 streak lost